### PR TITLE
Add R binding to API docs

### DIFF
--- a/content/docs/reference/api.md
+++ b/content/docs/reference/api.md
@@ -12,5 +12,6 @@ Automerge has implementations, ports, and bindings for a handful of other langua
 
 - [C](https://github.com/automerge/automerge/tree/main/rust/automerge-c)
 - [Python](https://github.com/automerge/automerge-py)
+- [R](https://posit-dev.github.io/automerge-r/)
 - [Rust](https://github.com/automerge/automerge-rs)
 - [Swift](https://automerge.org/automerge-swift/documentation/automerge/)


### PR DESCRIPTION
With the GitHub repo at `https://github.com/posit-dev/automerge-r/`.
The R package site I've linked to is a bit friendlier though and what R folks are used to.