### PR TITLE
Improve ephemeral messaging example

### DIFF
--- a/content/docs/reference/repositories/ephemeral.md
+++ b/content/docs/reference/repositories/ephemeral.md
@@ -24,8 +24,8 @@ To receive you listen to the `"ephemeral-message"` event on the `DocHandle`
 
 ```typescript
 const handle = await repo.find("<some url>")
-handle.on("ephemeral-message", (message: any) => {
-    console.log("got an ephemeral message: ", message)
+handle.on("ephemeral-message", ({ handle, senderId, message }) => {
+  console.log("from", senderId, "on", handle.url, "got ephemeral message:",  message)
 })
 ```
 


### PR DESCRIPTION
The docs imply that the message we broadcast is the same data
structure that is received by `.on("ephemeral-message")`, but the
latter has an envelope. Update the example to make it clear an
envelope is present.

As reported in https://discord.com/channels/1200006940210757672/1203792520153399327/1448672579396042845
